### PR TITLE
Настроить автосборку и исправить окно на маке

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -18,8 +18,12 @@ import traceback
 
 # Настройка пути к браузерам Playwright
 # Корректно работает как из исходников, так и из упакованного PyInstaller-exe
-if getattr(sys, 'frozen', False):  # запущено из собранного exe
-    base_dir = os.path.dirname(sys.executable)
+# Определяем базовый каталог: в собранном onefile PyInstaller данные распаковываются
+# во временную папку, путь к которой хранится в sys._MEIPASS. Используем его, чтобы
+# найти встроенную папку ms-playwright.
+if getattr(sys, 'frozen', False):
+    # В onefile-режиме PyInstaller создаёт временную директорию _MEI***
+    base_dir = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
 else:
     base_dir = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
Update Playwright browser path resolution in `main.py` to support PyInstaller one-file executables, resolving the 'Executable doesn't exist' error.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae8d7f25-303a-4d2c-899a-fcd50e81ab1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae8d7f25-303a-4d2c-899a-fcd50e81ab1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

